### PR TITLE
Fix a bug where refreshing on the main page, then trying to access the changelog would take you to the achievements screen.

### DIFF
--- a/frontend/src/js/views/viewManager.js
+++ b/frontend/src/js/views/viewManager.js
@@ -83,7 +83,7 @@ export class ViewManager {
                 this.viewStorage.playerCustomizationScreen=new playerCustomizationView(false);
                 this.viewStorage.peerConnectScreen = new connectToPeersView(false);
                 this.viewStorage.changelog = new changelogView(false);
-                this.viewStorage.changelog = new achievementsView(false);
+                this.viewStorage.achievements = new achievementsView(false);
                 this.viewStorage.cameraPref = new cameraPref(false);
                 break;
             case this.views.achievements:


### PR DESCRIPTION
This is a one-line bug fix for a bug I found with the main